### PR TITLE
Swapping out lodash merge util to allow for recursive config merging

### DIFF
--- a/packages/core/lib/utils.js
+++ b/packages/core/lib/utils.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const exec = require('child_process').exec;
-const merge = require('lodash.merge');
+const merge = require('merge').recursive;
 const notifier = require('node-notifier');
 const yaml = require('js-yaml');
 const fs = require('fs');

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -19,7 +19,7 @@
   },
   "dependencies": {
     "js-yaml": "^3.8.3",
-    "lodash.merge": "^4.6.0",
+    "merge": "^1.2.0",
     "node-notifier": "^5.1.2"
   }
 }


### PR DESCRIPTION
I believe this should address the use cases brought up in issue #10 and hopefully better match expectations on how config overrides vs inherited config values would typically behave. For example:

Given the following default params:
```
module.exports = {
  src: [
    'scss/**/*.scss',
  ],
  dest: 'dest/',
  extraWatches: [],
  flattenDestOutput: true,
  // enables additional debugging information in the output file as CSS comments
  sourceComments: false,
  sourceMapEmbed: false,
  // tell the compiler whether you want 'expanded' or 'compressed' output code
  outputStyle: 'expanded',
  // https://github.com/ai/browserslist#queries
  autoPrefixerBrowsers: [
    'last 3 versions',
    'IE >= 10',
  ],
  includePaths: [
    './node_modules',
  ],
  // Stylelint - requires config file setup ~ http://stylelint.io
  lint: {
    enabled: false,
    onWatch: true,
  },
  // http://sassdoc.com
  sassdoc: {
    enabled: false,
    dest: 'dest/sassdoc',
    verbose: false,
    basePath: '',
    exclude: [],
    theme: 'default',
    // http://sassdoc.com/customising-the-view/#sort
    sort: [
      'file',
      'line>',
      'group'
    ]
  },
};
```

With the following overrides configured when including the example Sass task:
```
const cssTasks = require('@theme-tools/plugin-sass')({
  src: [
    'pattern-lab/source/_scss/**/*.scss'
  ],
  dest: 'assets',
  lint: {
    enabled: false
  },
  autoPrefixerBrowsers: [
    'IE >= 9'
  ],
  sassdoc: {
    enabled: true,
    sort: [
      'file',
      'line>'
    ]
  }
});
```


## Resulting config BEFORE (note the autoPrefixerBrowsers + sassdoc.sort settings aren't quite what the config overrides would expect...)
```
{
  src: ['pattern-lab/source/_scss/**/*.scss'],
  dest: 'assets',
  extraWatches: [],
  flattenDestOutput: true,
  sourceComments: false,
  sourceMapEmbed: false,
  outputStyle: 'expanded',
  autoPrefixerBrowsers: ['IE >= 9', 'IE >= 10'],
  includePaths: ['./node_modules'],
  lint: {
    enabled: false,
    onWatch: true
  },
  sassdoc: {
    enabled: true,
    dest: 'dest/sassdoc',
    verbose: false,
    basePath: '',
    exclude: [],
    theme: 'default',
    sort: ['line>', 'file', 'group']
  }
}
```


## Resulting config AFTER updates (autoPrefixerBrowsers + sassdoc.sort overwritten vs merged to better match expectations)
```
{
  src: ['pattern-lab/source/_scss/**/*.scss'],
  dest: 'assets',
  extraWatches: [],
  flattenDestOutput: true,
  sourceComments: false,
  sourceMapEmbed: false,
  outputStyle: 'expanded',
  autoPrefixerBrowsers: ['IE >= 9'],
  includePaths: ['./node_modules'],
  lint: {
    enabled: false,
    onWatch: true
  },
  sassdoc: {
    enabled: true,
    dest: 'dest/sassdoc',
    verbose: false,
    basePath: '',
    exclude: [],
    theme: 'default',
    sort: ['line>', 'file']
  }
}
```